### PR TITLE
[Implement] Buffer.concat

### DIFF
--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -12,12 +12,7 @@ export class Buffer extends Uint8Array {
     return new Buffer(size);
   }
 
-  public static concat<T>(items: T, length: i32): Buffer {
-    if (!isArray<T>()) {
-      ERROR("Buffer.concat<T> must accept an Array where T extends Array<Uint8Array | Buffer>");
-    }
-    assert(unchecked(items[0]) instanceof Uint8Array); // Can this be a static check?
-
+  public static concat(items: Buffer[], length: i32): Buffer {
     let size: usize = 0;
     let itemCount = usize(items.length);
     let itemsDataStart = items.dataStart;
@@ -34,7 +29,7 @@ export class Buffer extends Uint8Array {
     let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
 
     result.data = changetype<ArrayBuffer>(buffer);
-    result.dataStart = changetype<usize>(buffer);
+    result.dataStart = buffer;
     let start: usize = result.dataStart;
     for (let i: usize = 0; i < itemCount && size > 0; i++) {
       let item = load<usize>(itemsDataStart + (i << alignof<usize>()));
@@ -55,7 +50,7 @@ export class Buffer extends Uint8Array {
     // This retains the pointer to the result Buffer.
     let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
     result.data = changetype<ArrayBuffer>(buffer);
-    result.dataStart = changetype<usize>(buffer);
+    result.dataStart = buffer;
     result.dataLength = size;
     return result;
   }

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -12,9 +12,12 @@ export class Buffer extends Uint8Array {
     return new Buffer(size);
   }
 
-  public static concat(items: Buffer[], length: i32): Buffer {
+  public static concat(items: Array<Buffer>, length: i32): Buffer {
+    // assert the list itself isn't null
+    assert(items != null);
+
     let size: usize = 0;
-    let itemCount = usize(items.length);
+    let itemCount = <usize>items.length;
     let itemsDataStart = items.dataStart;
 
     for (let i: usize = 0; i < itemCount; i++) {
@@ -22,8 +25,9 @@ export class Buffer extends Uint8Array {
       if (item == 0) continue;
       size += <usize>load<u32>(item, offsetof<Uint8Array>("dataLength"));
     }
-    size = min<usize>(usize(length), size);
-    assert(items);
+
+    // account for passed concat buffer length
+    size = min<usize>(<usize>length, size);
 
     let buffer = __alloc(size, idof<ArrayBuffer>());
     let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
@@ -33,7 +37,7 @@ export class Buffer extends Uint8Array {
     let start: usize = result.dataStart;
     for (let i: usize = 0; i < itemCount && size > 0; i++) {
       let item = load<usize>(itemsDataStart + (i << alignof<usize>()));
-      if (item == 0) continue;
+      if (item == null) continue;
       let count = min<u32>(size, <usize>load<u32>(item, offsetof<Uint8Array>("dataLength")));
       memory.copy(start, load<usize>(item, offsetof<Uint8Array>("dataStart")), count);
       start += count;

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -29,7 +29,7 @@ export class Buffer extends Uint8Array {
     }
 
     // account for passed concat buffer length
-    size = min<usize>(<usize>length, size);
+    size = min(<usize>length, size);
 
     let arrayBuffer = __alloc(size, idof<ArrayBuffer>());
     let result = __alloc(offsetof<Buffer>(), idof<Buffer>());
@@ -43,7 +43,7 @@ export class Buffer extends Uint8Array {
       let item = load<usize>(itemsDataStart + (i << alignof<usize>()));
       // if Buffer is null, continue
       if (item == 0) continue;
-      let count = min<usize>(size, <usize>load<u32>(item, offsetof<Buffer>("byteLength")));
+      let count = min(size, <usize>load<u32>(item, offsetof<Buffer>("byteLength")));
       memory.copy(start, load<usize>(item, offsetof<Buffer>("dataStart")), count);
       start += count;
       size -= count;

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -12,9 +12,9 @@ export class Buffer extends Uint8Array {
     return new Buffer(size);
   }
 
-  public static concat<T extends Uint8Array>(items: Array<T>, length: i32): Buffer {
-    // assert the list itself isn't null
-    assert(items != null);
+  public static concat<T extends Uint8Array>(items: Array<T>, length: i32 = i32.MAX_VALUE): Buffer {
+    if (items.length == 0) return new Buffer(0);
+    if (length < 0) throw new Error(E_INDEXOUTOFRANGE);
 
     let size: usize = 0;
     let itemCount = <usize>items.length;
@@ -36,7 +36,8 @@ export class Buffer extends Uint8Array {
 
     // assemble the Buffer
     store<usize>(result, __retain(arrayBuffer), offsetof<Buffer>("buffer"));
-    store<usize>(result, arrayBuffer, offsetof<Buffer>("byteLength"));
+    store<usize>(result, arrayBuffer, offsetof<Buffer>("dataStart"));
+    store<u32>(result, <u32>size, offsetof<Buffer>("byteLength"));
 
     let start = arrayBuffer;
     for (let i: usize = 0; i32(i < itemCount) & i32(size > 0); i++) {

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -12,7 +12,7 @@ export class Buffer extends Uint8Array {
     return new Buffer(size);
   }
 
-  public static concat(items: Array<Buffer>, length: i32): Buffer {
+  public static concat<T extends Uint8Array>(items: Array<T>, length: i32): Buffer {
     // assert the list itself isn't null
     assert(items != null);
 

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -1,6 +1,7 @@
 import { BLOCK_MAXSIZE } from "rt/common";
 import { E_INVALIDLENGTH, E_INDEXOUTOFRANGE } from "util/error";
 import { Uint8Array } from "typedarray";
+import { Array } from "array";
 
 export class Buffer extends Uint8Array {
   constructor(size: i32) {
@@ -9,6 +10,42 @@ export class Buffer extends Uint8Array {
 
   public static alloc(size: i32): Buffer {
     return new Buffer(size);
+  }
+
+  public static concat<T>(items: T, length: i32): Buffer {
+    if (!isArray<T>()) {
+      ERROR("Buffer.concat<T> must accept an Array where T extends Array<Uint8Array | Buffer>");
+    }
+    assert(unchecked(items[0]) instanceof Uint8Array); // Can this be a static check?
+
+    let size: usize = 0;
+    let itemCount = usize(items.length);
+    let itemsDataStart = items.dataStart;
+
+    for (let i: usize = 0; i < itemCount; i++) {
+      let item = load<usize>(itemsDataStart + (i << alignof<usize>()));
+      if (item == 0) continue;
+      size += <usize>load<u32>(item, offsetof<Uint8Array>("dataLength"));
+    }
+    size = min<usize>(usize(length), size);
+    assert(items);
+
+    let buffer = __alloc(size, idof<ArrayBuffer>());
+    let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+
+    result.data = changetype<ArrayBuffer>(buffer);
+    result.dataStart = changetype<usize>(buffer);
+    let start: usize = result.dataStart;
+    for (let i: usize = 0; i < itemCount && size > 0; i++) {
+      let item = load<usize>(itemsDataStart + (i << alignof<usize>()));
+      if (item == 0) continue;
+      let count = min<u32>(size, <usize>load<u32>(item, offsetof<Uint8Array>("dataLength")));
+      memory.copy(start, load<usize>(item, offsetof<Uint8Array>("dataStart")), count);
+      start += count;
+      size -= count;
+    }
+
+    return result;
   }
 
   @unsafe public static allocUnsafe(size: i32): Buffer {

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -3,4 +3,6 @@ declare class Buffer extends Uint8Array {
   static alloc(size: i32): Buffer;
   /** This method allocates a new Buffer of indicated size. This is unsafe because the data is not zeroed. */
   static allocUnsafe(size: i32): Buffer;
+  /** This method concatenates an array of `U extends Uint8Array` objects. */
+  static concat<T extends Uint8Array[]>(list: T, totalLength: i32): Buffer;
 }

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -4,5 +4,5 @@ declare class Buffer extends Uint8Array {
   /** This method allocates a new Buffer of indicated size. This is unsafe because the data is not zeroed. */
   static allocUnsafe(size: i32): Buffer;
   /** This method concatenates an array of `U extends Uint8Array` objects. */
-  static concat<T extends Uint8Array[]>(list: T, totalLength: i32): Buffer;
+  static concat(list: Buffer[], totalLength: i32): Buffer;
 }

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -4,7 +4,7 @@ declare class Buffer extends Uint8Array {
   /** This method allocates a new Buffer of indicated size. This is unsafe because the data is not zeroed. */
   static allocUnsafe(size: i32): Buffer;
   /** This method concatenates an array of `U extends Uint8Array` objects. */
-  static concat(list: Buffer[], totalLength: i32): Buffer;
+  static concat(list: Buffer[], totalLength?: i32): Buffer;
   /** This method asserts a value is a Buffer object via `value instanceof Buffer`. */
   static isBuffer<T>(value: T): bool;
   /** Reads a signed integer at the designated offset. */

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -36,7 +36,7 @@ describe("buffer", () => {
     expect(Buffer.alloc(10)).toBeTruthy();
     expect(Buffer.alloc(10)).toHaveLength(10);
     let buff = Buffer.alloc(100);
-    for (let i = 0; i < buff.length; i++) expect<u8>(buff[i]).toBe(0);
+    for (let i = 0; i < buff.length; i++) expect(buff[i]).toBe(0);
     expect(buff.buffer).not.toBeNull();
     expect(buff.byteLength).toBe(100);
     expect(() => { Buffer.alloc(-1); }).toThrow();
@@ -56,19 +56,18 @@ describe("buffer", () => {
   });
 
   test("#concat", () => {
-    let list: Buffer[] = new Array<Buffer>(0);
-    for (let i = 0; i < 5; i++) {
-      let buff = Buffer.alloc(5 - i);
-      for (let j = 0; j < (5 - i); j++) {
-         buff[j] = u8(i);
-      }
-      list.push(buff);
-    }
-    let actual = Buffer.concat(list, 15);
+    let actual = Buffer.concat([
+      create<Buffer>([0, 0, 0, 0, 0]),
+      create<Buffer>([1, 1, 1, 1]),
+      create<Buffer>([2, 2, 2]),
+      create<Buffer>([3, 3]),
+      create<Buffer>([4]),
+      create<Buffer>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    ], 15);
 
     let expected = create<Buffer>([0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4]);
 
-    expect<Buffer>(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected);
   });
 
   test("#isBuffer", () => {
@@ -268,7 +267,7 @@ describe("buffer", () => {
     expect(buff.writeInt32LE(-559038737)).toBe(4);
     expect(buff.writeInt32LE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);
-    expect<Buffer>(buff).toStrictEqual(result);
+    expect(buff).toStrictEqual(result);
     expect(() => {
       let newBuff = new Buffer(1);
       newBuff.writeInt32LE(0);

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -42,4 +42,29 @@ describe("buffer", () => {
     // TODO: expectFn(() => { Buffer.allocUnsafe(-1); }).toThrow();
     // TODO: expectFn(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
   });
+
+  test("#concat", () => {
+    let list: Buffer[] = new Array<Buffer>(0);
+    for (let i = 0; i < 5; i++) {
+      let buff = Buffer.alloc(5 - i);
+      for (let j = 0; j < (5 - i); j++) {
+         buff[j] = u8(i);
+      }
+      list.push(buff);
+    }
+    let actual: Buffer = Buffer.concat<Buffer[]>(list, 15);
+
+    let expected: Buffer = Buffer.alloc(15);
+    expected[5] = 1;
+    expected[6] = 1;
+    expected[7] = 1;
+    expected[8] = 1;
+    expected[9] = 2;
+    expected[10] = 2;
+    expected[11] = 2;
+    expected[12] = 3;
+    expected[13] = 3;
+    expected[14] = 4;
+    expect<ArrayBuffer>(actual.buffer).toStrictEqual(expected.buffer);
+  });
 });

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -64,13 +64,11 @@ describe("buffer", () => {
       }
       list.push(buff);
     }
-    let actual: Buffer = Buffer.concat(list, 15);
+    let actual = Buffer.concat(list, 15);
 
-    let expected: Buffer = create<Buffer>([0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4]);
+    let expected = create<Buffer>([0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4]);
 
-    // TODO: When as-pect releases 2.2.1
-    // expect<Buffer>(actual).toStrictEqual(expected);
-    expect<ArrayBuffer>(actual.buffer).toStrictEqual(expected.buffer);
+    expect<Buffer>(actual).toStrictEqual(expected);
   });
 
   test("#isBuffer", () => {

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -1,3 +1,9 @@
+function bufferFrom(values: i32[]): Buffer {
+  let buffer = new Buffer(values.length);
+  for (let i = 0; i < values.length; i++) buffer[i] = <u8>values[i];
+  return buffer;
+}
+
 /**
  * This is the buffer test suite. For each prototype function, put a single test
  * function call here.
@@ -9,8 +15,6 @@
  *   });
  * });
  */
-import { BLOCK_MAXSIZE } from "rt/common";
-
 describe("buffer", () => {
   test("#constructor", () => {
     expect<Buffer>(new Buffer(0)).toBeTruthy();
@@ -52,19 +56,12 @@ describe("buffer", () => {
       }
       list.push(buff);
     }
-    let actual: Buffer = Buffer.concat<Buffer[]>(list, 15);
+    let actual: Buffer = Buffer.concat(list, 15);
 
-    let expected: Buffer = Buffer.alloc(15);
-    expected[5] = 1;
-    expected[6] = 1;
-    expected[7] = 1;
-    expected[8] = 1;
-    expected[9] = 2;
-    expected[10] = 2;
-    expected[11] = 2;
-    expected[12] = 3;
-    expected[13] = 3;
-    expected[14] = 4;
+    let expected: Buffer = bufferFrom([0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4]);
+
+    // TODO: When as-pect releases 2.2.1
+    // expect<Buffer>(actual).toStrictEqual(expected);
     expect<ArrayBuffer>(actual.buffer).toStrictEqual(expected.buffer);
   });
 });

--- a/tests/node.js
+++ b/tests/node.js
@@ -41,14 +41,15 @@ class Reporter extends EmptyReporter {
     else           process.stdout.write("Test      : " + group.name + " -> " + test.name + " ❌ FAIL\n");
 
     if (!test.pass) {
-      process.stdout.write("Actual    : " + test.actual.message + "\n");
-      process.stdout.write("Expected  : " + test.expected.message + "\n");
+      if (test.actual) process.stdout.write("Actual    : " + test.actual.message + "\n");
+      if (test.expected) process.stdout.write("Expected  : " + test.expected.message + "\n");
     }
 
     if (test.logs.length > 0) {
       test.logs.forEach((e, i) => {
         if (i > 0) process.stdout.write("\n");
-        process.stdout.write("Log       : " + e.value);
+        if (e.bytes) process.stdout.write("Log       : " + Buffer.from(e.bytes).toString("hex"));
+        else         process.stdout.write("Log       : " + e.value);
       });
       process.stdout.write("\n");
     }


### PR DESCRIPTION
~Current problems:~

- ~No good logging for that extend `ArrayBufferView` (opened issue with as-pect https://github.com/jtenner/as-pect/issues/132 )~
- ~No good way of comparing things that extend `ArrayBufferView` (opened issue with as-pect https://github.com/jtenner/as-pect/issues/133 )~

```ts
expect<Buffer>(actual).toStrictEqual(expected); // should compare lengths and values
```

- ~No good way to create a buffer from scratch without a naive `Buffer.from<T>()` function~
    - ~Could create a helper function, but that's a todo~

This pull request is not blocked by anything. Current questions:

- Should we set the length parameter to `i32.MAX_VALUE`?
- Any suggestions for optimizations?
- Should we do a `null` check on the array? (in case of uninitialized field problems?)
