### PR TITLE
[Implement] Naive Buffer.from, and friends

### DIFF
--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -25,7 +25,7 @@ export class Buffer extends Uint8Array {
   }
 
   // @ts-ignore: Buffer returns on all valid branches
-  public static from<T>(value: T): Buffer {
+  public static from<T extends ArrayBufferView>(value: T): Buffer {
     // @ts-ignore: AssemblyScript treats this statement correctly
     if (value instanceof String[]) {
       let length = value.length;

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -6,7 +6,7 @@ import { Array } from "array";
 
 // @ts-ignore: Decorator
 @inline
-function assembleBuffer(arrayBuffer: usize, offset: usize, length: u32): Buffer {
+function allocBuffer(arrayBuffer: usize, offset: usize, length: u32): Buffer {
   let pointer = __alloc(offsetof<Buffer>(), idof<Buffer>());
   store<usize>(pointer, __retain(arrayBuffer), offsetof<Buffer>("buffer"));
   store<usize>(pointer, arrayBuffer + offset, offsetof<Buffer>("dataStart"));
@@ -26,7 +26,7 @@ export class Buffer extends Uint8Array {
   @unsafe static allocUnsafe(size: i32): Buffer {
     // range must be valid
     if (<usize>size > BLOCK_MAXSIZE) throw new RangeError(E_INVALIDLENGTH);
-    return assembleBuffer(__alloc(size, idof<ArrayBuffer>()), 0, size);
+    return allocBuffer(__alloc(size, idof<ArrayBuffer>()), 0, size);
   }
 
   public static fromArrayBuffer(buffer: ArrayBuffer, byteOffset: i32 = 0, length: i32 = -1): Buffer {
@@ -34,7 +34,7 @@ export class Buffer extends Uint8Array {
     if (i32(byteOffset < 0) | i32(byteOffset > buffer.byteLength - length)) throw new RangeError(E_INDEXOUTOFRANGE);
     if (length == 0) return new Buffer(0);
 
-    return assembleBuffer(changetype<usize>(buffer), <usize>byteOffset, <u32>length);
+    return allocBuffer(changetype<usize>(buffer), <usize>byteOffset, <u32>length);
   }
 
   public static fromString(value: string, encoding: string = "utf8"): Buffer {
@@ -52,7 +52,7 @@ export class Buffer extends Uint8Array {
     }
 
     // assemble the buffer
-    return assembleBuffer(changetype<usize>(buffer), 0, buffer.byteLength);
+    return allocBuffer(changetype<usize>(buffer), 0, buffer.byteLength);
   }
 
   public static fromArray<T extends ArrayBufferView>(value: T, offset: i32 = 0, length: i32 = -1): Buffer {
@@ -82,24 +82,24 @@ export class Buffer extends Uint8Array {
       }
     }
 
-    return assembleBuffer(arrayBuffer, 0, length);
+    return allocBuffer(arrayBuffer, 0, length);
   }
 
   public static fromBuffer(source: Buffer): Buffer {
     let length = source.byteLength;
     let data = __alloc(length, idof<ArrayBuffer>()); // retains
     memory.copy(data, source.dataStart, length);
-    return assembleBuffer(data, 0, length);
+    return allocBuffer(data, 0, length);
   }
 
   // @ts-ignore: Buffer returns on all valid branches
   public static from<T>(value: T): Buffer {
     if (value instanceof ArrayBuffer) {
-      return assembleBuffer(changetype<usize>(value), 0, value.byteLength);
+      return allocBuffer(changetype<usize>(value), 0, value.byteLength);
     } else if (value instanceof String) {
       // @ts-ignore value not instance of `string` does changetype<string>(value) work here?
       let buffer = String.UTF8.encode(value);
-      return assembleBuffer(changetype<usize>(buffer), 0, buffer.byteLength);
+      return allocBuffer(changetype<usize>(buffer), 0, buffer.byteLength);
     } else if (value instanceof Buffer) {
       return Buffer.fromBuffer(value);
     } else if (value instanceof ArrayBufferView) {
@@ -119,7 +119,7 @@ export class Buffer extends Uint8Array {
     end   = end   < 0 ? max(len + end,   0) : min(end,   len);
     end   = max(end, begin);
 
-    return assembleBuffer(changetype<usize>(this.buffer), <usize>this.byteOffset + <usize>begin, <u32>end - <u32>begin);
+    return allocBuffer(changetype<usize>(this.buffer), <usize>this.byteOffset + <usize>begin, <u32>end - <u32>begin);
   }
 
   readInt8(offset: i32 = 0): i8 {

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -29,7 +29,6 @@ export class Buffer extends Uint8Array {
     // @ts-ignore: AssemblyScript treats this statement correctly
     if (value instanceof String[]) {
       let length = value.length;
-      log<i32>(length);
       let buffer = __alloc(length, idof<ArrayBuffer>());
       let sourceStart = value.dataStart;
       for (let i = 0; i < length; i++) {
@@ -72,7 +71,6 @@ export class Buffer extends Uint8Array {
       result.dataStart = buffer;
       result.dataLength = u32(length);
       return result;
-      
     }
     ERROR("Cannot call Buffer.from<T>() where T is not a string, Buffer, ArrayBuffer, Array, or Array-like Object.");
   }

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -1,6 +1,7 @@
 import { BLOCK_MAXSIZE } from "rt/common";
 import { E_INVALIDLENGTH, E_INDEXOUTOFRANGE } from "util/error";
 import { Uint8Array } from "typedarray";
+import { ArrayBufferView } from "arraybuffer";
 
 export class Buffer extends Uint8Array {
   constructor(size: i32) {
@@ -21,5 +22,58 @@ export class Buffer extends Uint8Array {
     result.dataStart = changetype<usize>(buffer);
     result.dataLength = size;
     return result;
+  }
+
+  // @ts-ignore: Buffer returns on all valid branches
+  public static from<T>(value: T): Buffer {
+    // @ts-ignore: AssemblyScript treats this statement correctly
+    if (value instanceof String[]) {
+      let length = value.length;
+      log<i32>(length);
+      let buffer = __alloc(length, idof<ArrayBuffer>());
+      let sourceStart = value.dataStart;
+      for (let i = 0; i < length; i++) {
+        let str = changetype<string>(load<usize>(sourceStart + (usize(i) << alignof<usize>())));
+        let value = parseFloat(str); // parseFloat is still naive
+        store<u8>(buffer + usize(i), isFinite<f64>(value) ? u8(value) : u8(0));
+      }
+      let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+      result.data = changetype<ArrayBuffer>(buffer);
+      result.dataStart = changetype<usize>(value);
+      result.dataLength = length;
+      return result;
+    } else if (value instanceof ArrayBuffer) {
+      let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+      result.data = value;
+      result.dataStart = changetype<usize>(value);
+      result.dataLength = value.byteLength;
+      return result;
+    } else if (value instanceof String) {
+      // @ts-ignore value not instance of `string` does changetype<string>(value) work here?
+      let buffer = String.UTF8.encode(value);
+      let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+      result.data = buffer;
+      result.dataStart = changetype<usize>(buffer);
+      result.dataLength = buffer.byteLength;
+      return result;
+    } else if (value instanceof Buffer) {
+      let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+      result.data = value.buffer;
+      result.dataStart = value.dataStart;
+      result.dataLength = value.dataLength;
+      return result;
+    } else if (value instanceof ArrayBufferView) {
+      let length = value.length;
+      let buffer = __alloc(length, idof<ArrayBuffer>());
+      let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
+      // @ts-ignore: value[i] is implied to work
+      for (let i = 0; i < length; i++) store<u8>(buffer + usize(i), u8(unchecked(value[i])));
+      result.data = changetype<ArrayBuffer>(buffer);
+      result.dataStart = buffer;
+      result.dataLength = u32(length);
+      return result;
+      
+    }
+    ERROR("Cannot call Buffer.from<T>() where T is not a string, Buffer, ArrayBuffer, Array, or Array-like Object.");
   }
 }

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -28,17 +28,18 @@ export class Buffer extends Uint8Array {
   public static from<T extends ArrayBufferView>(value: T): Buffer {
     // @ts-ignore: AssemblyScript treats this statement correctly
     if (value instanceof String[]) {
-      let length = value.length;
+      let length = <usize>value.length;
       let buffer = __alloc(length, idof<ArrayBuffer>());
       let sourceStart = value.dataStart;
-      for (let i = 0; i < length; i++) {
+      for (let i: usize = 0; i < length; i++) {
         let str = changetype<string>(load<usize>(sourceStart + (<usize>i << alignof<usize>())));
         let value = parseFloat(str); // parseFloat is still naive
-        store<u8>(buffer + usize(i), isFinite<f64>(value) ? u8(value) : u8(0));
+        trace("float values", 2, value, u8(value));
+        store<u8>(buffer + i, isFinite(value) ? u8(value) : u8(0));
       }
       let result = changetype<Buffer>(__alloc(offsetof<Buffer>(), idof<Buffer>()));
       result.data = changetype<ArrayBuffer>(buffer);
-      result.dataStart = changetype<usize>(value);
+      result.dataStart = changetype<usize>(buffer);
       result.dataLength = length;
       return result;
     } else if (value instanceof ArrayBuffer) {

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -74,6 +74,7 @@ export class Buffer extends Uint8Array {
     }
     ERROR("Cannot call Buffer.from<T>() where T is not a string, Buffer, ArrayBuffer, Array, or Array-like Object.");
   }
+
   public static isBuffer<T>(value: T): bool {
     return value instanceof Buffer;
   }

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -45,7 +45,8 @@ export class Buffer extends Uint8Array {
       buffer = String.UTF16.encode(value);
     } else if (encoding == "hex") {
       buffer = Buffer.HEX.encode(value);
-      // TODO: add ascii encoding
+    } else if (encoding == "ascii") {
+      buffer = Buffer.ASCII.encode(value);
     } else {
       throw new TypeError("Invalid string encoding.");
     }

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -3,4 +3,6 @@ declare class Buffer extends Uint8Array {
   static alloc(size: i32): Buffer;
   /** This method allocates a new Buffer of indicated size. This is unsafe because the data is not zeroed. */
   static allocUnsafe(size: i32): Buffer;
+  /** This method creates a Buffer from the given reference. This method is naive and defaults to utf8 encoding for strings. */
+  static from<T>(value: T): Buffer;
 }

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -5,6 +5,14 @@ declare class Buffer extends Uint8Array {
   static allocUnsafe(size: i32): Buffer;
   /** This method creates a Buffer from the given reference. This method is naive and defaults to utf8 encoding for strings. */
   static from<T>(value: T): Buffer;
+  /** This method creates a buffer from a given string. This method defaults to utf8 encoding. */
+  public static fromString(value: string, encoding?: string): Buffer;
+  /** This method creates a buffer that uses the given ArrayBuffer as an underlying value. */
+  public static fromArrayBuffer(buffer: ArrayBuffer, byteOffset?: i32 , length?: i32): Buffer;
+  /** This method creates a copy of the buffer using memory.copy(). */
+  public static fromBuffer(source: Buffer): Buffer;
+  /** This method creates a new Buffer by copying the underlying values to a new ArrayBuffer and coercing each one to an 8 bit integer value. */
+  public static fromArray<T extends ArrayBufferView<number | string>>(value: T, offset?: i32, length?: i32): Buffer;
   /** This method asserts a value is a Buffer object via `value instanceof Buffer`. */
   static isBuffer<T>(value: T): bool;
   /** Reads a signed integer at the designated offset. */

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -1,10 +1,3 @@
-function bufferFrom<T>(values: valueof<T>[]): T {
-  let buffer = instantiate<T>(values.length);
-  // @ts-ignore
-  for (let i = 0; i < values.length; i++) buffer[i] = values[i];
-  return buffer;
-}
-
 /**
  * This is the buffer test suite. For each prototype function, put a single test
  * function call here.

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -36,7 +36,7 @@ describe("buffer", () => {
     expect(Buffer.alloc(10)).toBeTruthy();
     expect(Buffer.alloc(10)).toHaveLength(10);
     let buff = Buffer.alloc(100);
-    for (let i = 0; i < buff.length; i++) expect<u8>(buff[i]).toBe(0);
+    for (let i = 0; i < buff.length; i++) expect(buff[i]).toBe(0);
     expect(buff.buffer).not.toBeNull();
     expect(buff.byteLength).toBe(100);
     expect(() => { Buffer.alloc(-1); }).toThrow();
@@ -89,7 +89,7 @@ describe("buffer", () => {
     expect(floatBuff).toStrictEqual(floatBuffExpected, "float values");
 
     let strArrayExpected = create<Buffer>([1, 2, 3, 4, 5, 6, 7, 0, 0, 0]);
-    let stringValues: string[] = ["1.1", "2.2", "3.3", "4.4", "5.5", "6.6", "7.7", "Infinity", "NaN", "-Infinity"];
+    let stringValues = ["1.1", "2.2", "3.3", "4.4", "5.5", "6.6", "7.7", "Infinity", "NaN", "-Infinity"];
     let strArrayActual = Buffer.from(stringValues);
     expect(strArrayActual).toStrictEqual(strArrayExpected, "Array Of Strings");
   });
@@ -118,10 +118,10 @@ describe("buffer", () => {
 
     // Changing the original Uint16Array changes the Buffer also.
     arr[1] = 6000;
-    expect<Buffer>(buf).toStrictEqual(create<Buffer>([0x88, 0x13, 0x70, 0x17]));
+    expect(buf).toStrictEqual(create<Buffer>([0x88, 0x13, 0x70, 0x17]));
 
     // test optional parameters
-    expect<Buffer>(Buffer.fromArrayBuffer(arr.buffer, 1, 2)).toStrictEqual(create<Buffer>([0x13, 0x70]));
+    expect(Buffer.fromArrayBuffer(arr.buffer, 1, 2)).toStrictEqual(create<Buffer>([0x13, 0x70]));
 
     // TODO:
     // expectFn(() => {
@@ -138,20 +138,20 @@ describe("buffer", () => {
     let buff1 = create<Buffer>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     let buff2 = Buffer.fromBuffer(buff1);
 
-    expect<Buffer>(buff1).not.toBe(buff2);
-    expect<ArrayBuffer>(buff1.buffer).not.toBe(buff2.buffer);
-    expect<Buffer>(buff1).toStrictEqual(buff2);
+    expect(buff1).not.toBe(buff2);
+    expect(buff1.buffer).not.toBe(buff2.buffer);
+    expect(buff1).toStrictEqual(buff2);
   });
 
   test(".fromArray", () => {
     let buff1 = create<Uint16Array>([3, 6, 9, 12, 15, 18, 21]);
     let buff2 = Buffer.fromArray(buff1, 2, 4);
     let expected = create<Buffer>([9, 12, 15, 18]);
-    expect<Buffer>(buff2).toStrictEqual(expected);
+    expect(buff2).toStrictEqual(expected);
 
     // test string values
     buff2 = Buffer.fromArray(["9.2", "12.1", "15.3", "18.8"]);
-    expect<Buffer>(buff2).toStrictEqual(expected);
+    expect(buff2).toStrictEqual(expected);
   });
 
   // todo: fromArray
@@ -354,7 +354,7 @@ describe("buffer", () => {
     expect(buff.writeInt32LE(-559038737)).toBe(4);
     expect(buff.writeInt32LE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);
-    expect<Buffer>(buff).toStrictEqual(result);
+    expect(buff).toStrictEqual(result);
     expect(() => {
       let newBuff = new Buffer(1);
       newBuff.writeInt32LE(0);

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -21,7 +21,7 @@ function create<T>(values: valueof<T>[]): T {
 }
 
 describe("buffer", () => {
-  test("#constructor", () => {
+  test(".constructor", () => {
     expect<Buffer>(new Buffer(0)).toBeTruthy();
     expect<Buffer>(new Buffer(10)).toHaveLength(10);
     let myBuffer = new Buffer(10);
@@ -31,7 +31,7 @@ describe("buffer", () => {
     // TODO: expectFn(() => { new Buffer(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
-  test("#alloc", () => {
+  test(".alloc", () => {
     expect<Buffer>(Buffer.alloc(10)).toBeTruthy();
     expect<Buffer>(Buffer.alloc(10)).toHaveLength(10);
     let buff = Buffer.alloc(100);
@@ -42,7 +42,7 @@ describe("buffer", () => {
     // TODO: expectFn(() => { Buffer.alloc(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
-  test("#allocUnsafe", () => {
+  test(".allocUnsafe", () => {
     expect<Buffer>(Buffer.allocUnsafe(10)).toBeTruthy();
     expect<Buffer>(Buffer.allocUnsafe(10)).toHaveLength(10);
     let buff = Buffer.allocUnsafe(100);
@@ -91,6 +91,70 @@ describe("buffer", () => {
     let strArrayActual = Buffer.from<Array<String>>(stringValues);
     expect<Buffer>(strArrayActual).toStrictEqual(strArrayExpected, "Array Of Strings");
   });
+
+  test(".fromString", () => {
+    // public static fromString(value: string, encoding: string = "utf8"): Buffer {
+    // default encoding is utf8
+    let expected = create<Buffer>([0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0xc3, 0xa9, 0x73, 0x74])
+    expect<Buffer>(Buffer.from('this is a tést'))
+      .toStrictEqual(expected);
+
+    expect<Buffer>(Buffer.fromString('7468697320697320612074c3a97374', 'hex'))
+      .toStrictEqual(expected);
+  });
+
+  test(".fromArrayBuffer", () => {
+    const arr = new Uint16Array(2);
+
+    arr[0] = 5000;
+    arr[1] = 4000;
+
+    // Shares memory with `arr`.
+    const buf = Buffer.fromArrayBuffer(arr.buffer);
+
+
+    expect<Buffer>(buf).toStrictEqual(create<Buffer>([0x88, 0x13, 0xa0, 0x0f]));
+
+    // Changing the original Uint16Array changes the Buffer also.
+    arr[1] = 6000;
+    expect<Buffer>(buf).toStrictEqual(create<Buffer>([0x88, 0x13, 0x70, 0x17]));
+
+    // test optional parameters
+    expect<Buffer>(Buffer.fromArrayBuffer(arr.buffer, 1, 2)).toStrictEqual(create<Buffer>([0x13, 0x70]));
+
+    // TODO:
+    // expectFn(() => {
+    //   let value = create<Uint16Array>([5000, 4000]); // 4 bytes
+    //   Buffer.fromArrayBuffer(value.buffer, 5);
+    // }).toThrow("offset out of bounds should throw");
+    // expectFn(() => {
+    //   let value = create<Uint16Array>([5000, 4000]); // 4 bytes
+    //   Buffer.fromArrayBuffer(value.buffer, 2, 3);
+    // }).toThrow("length out of bounds should throw");
+  });
+
+  test(".fromBuffer", () => {
+    let buff1 = create<Buffer>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let buff2 = Buffer.fromBuffer(buff1);
+
+    expect<Buffer>(buff1).not.toBe(buff2);
+    expect<ArrayBuffer>(buff1.buffer).not.toBe(buff2.buffer);
+    expect<Buffer>(buff1).toStrictEqual(buff2);
+  });
+
+  test(".fromArray", () => {
+    let buff1 = create<Uint16Array>([3, 6, 9, 12, 15, 18, 21]);
+    let buff2 = Buffer.fromArray(buff1, 2, 4);
+    let expected = create<Buffer>([9, 12, 15, 18]);
+    expect<Buffer>(buff2).toStrictEqual(expected);
+
+    // test string values
+    buff2 = Buffer.fromArray<string[]>(["9.2", "12.1", "15.3", "18.8"]);
+    expect<Buffer>(buff2).toStrictEqual(expected);
+  });
+
+  // todo: fromArray
+  // todo: fromBuffer
 
   test("#isBuffer", () => {
     let a = "";

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -60,9 +60,7 @@ describe("buffer", () => {
    * There are no good solutions. Only tradeoffs. Function overloading is the only
    * way to fix this problem.
    */
-  test("#from", () => {
-    // TODO: Switch to expect<Buffer>() when 2.2.1 releases
-
+  test(".from", () => {
     // Buffer.from uses the array buffer reference
     let buff = new ArrayBuffer(100);
     for (let i = 0; i < 100; i++) store<u8>(changetype<usize>(buff), u8(i));
@@ -72,26 +70,26 @@ describe("buffer", () => {
 
     // strings are utf8 encoded by default
     let strBuffer = Buffer.from<string>("Hello world!");
-    let strBufferExpected = bufferFrom<Buffer>([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]);
-    expect<ArrayBuffer>(strBuffer.buffer).toStrictEqual(strBufferExpected.buffer);
+    let strBufferExpected = create<Buffer>([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]);
+    expect<Buffer>(strBuffer).toStrictEqual(strBufferExpected);
 
     // buffer returns a new reference view to the same ArrayBuffer
     let buff2 = Buffer.from<Buffer>(abBuffer);
     expect<Buffer>(buff2).not.toBe(abBuffer);
+    expect<Buffer>(buff2).toStrictEqual(abBuffer);
     expect<ArrayBuffer>(buff2.buffer).toBe(abBuffer.buffer);
-    expect<usize>(buff2.dataStart).toBe(abBuffer.dataStart);
-    expect<u32>(buff2.dataLength).toBe(abBuffer.dataLength);
+    expect<i32>(buff2.byteOffset).toBe(abBuffer.byteOffset);
 
     // else if it extends ArrayBufferView simply converts all the values
-    let floats = bufferFrom<Float32Array>([1.1, 2.2, 3.3]);
+    let floats = create<Float32Array>([1.1, 2.2, 3.3]);
     let floatBuff = Buffer.from<Float32Array>(floats);
-    let floatBuffExpected = bufferFrom<Buffer>([1, 2, 3]);
-    expect<ArrayBuffer>(floatBuff.buffer).toStrictEqual(floatBuffExpected.buffer);
+    let floatBuffExpected = create<Buffer>([1, 2, 3]);
+    expect<Buffer>(floatBuff).toStrictEqual(floatBuffExpected);
 
-    let strArrayExpected = bufferFrom<Buffer>([1, 2, 3, 4, 5, 6, 7, 0, 0, 0]);
+    let strArrayExpected = create<Buffer>([1, 2, 3, 4, 5, 6, 7, 0, 0, 0]);
     let stringValues: string[] = ["1.1", "2.2", "3.3", "4.4", "5.5", "6.6", "7.7", "Infinity", "NaN", "-Infinity"];
     let strArrayActual = Buffer.from<Array<String>>(stringValues);
-    expect<ArrayBuffer>(strArrayActual.buffer).toStrictEqual(strArrayExpected.buffer);
+    expect<Buffer>(strArrayActual).toStrictEqual(strArrayExpected, "Array Of Strings");
   });
 
   test("#isBuffer", () => {

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -1,3 +1,10 @@
+function bufferFrom<T>(values: valueof<T>[]): T {
+  let buffer = instantiate<T>(values.length);
+  // @ts-ignore
+  for (let i = 0; i < values.length; i++) buffer[i] = values[i];
+  return buffer;
+}
+
 /**
  * This is the buffer test suite. For each prototype function, put a single test
  * function call here.
@@ -41,5 +48,48 @@ describe("buffer", () => {
     expect<u32>(buff.byteLength).toBe(100);
     // TODO: expectFn(() => { Buffer.allocUnsafe(-1); }).toThrow();
     // TODO: expectFn(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
+  });
+
+
+  /**
+   * This specification is a tradeoff, because Buffer.from() takes _many_ parameters.
+   * Instead, the only common parameter is the first one, which results in Buffer.from
+   * acting in a very naive fashion. Perhaps an optional encoding parameter might be
+   * possible for strings, at least. However, this makes things more complicated.
+   * There are no good solutions. Only tradeoffs. Function overloading is the only
+   * way to fix this problem.
+   */
+  test("#from", () => {
+    // TODO: Switch to expect<Buffer>() when 2.2.1 releases
+
+    // Buffer.from uses the array buffer reference
+    let buff = new ArrayBuffer(100);
+    for (let i = 0; i < 100; i++) store<u8>(changetype<usize>(buff), u8(i));
+    let abBuffer = Buffer.from<ArrayBuffer>(buff);
+    expect<ArrayBuffer>(abBuffer.buffer).toStrictEqual(buff);
+    expect<ArrayBuffer>(abBuffer.buffer).toBe(buff);
+
+    // strings are utf8 encoded by default
+    let strBuffer = Buffer.from<string>("Hello world!");
+    let strBufferExpected = bufferFrom<Buffer>([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]);
+    expect<ArrayBuffer>(strBuffer.buffer).toStrictEqual(strBufferExpected.buffer);
+
+    // buffer returns a new reference view to the same ArrayBuffer
+    let buff2 = Buffer.from<Buffer>(abBuffer);
+    expect<Buffer>(buff2).not.toBe(abBuffer);
+    expect<ArrayBuffer>(buff2.buffer).toBe(abBuffer.buffer);
+    expect<usize>(buff2.dataStart).toBe(abBuffer.dataStart);
+    expect<u32>(buff2.dataLength).toBe(abBuffer.dataLength);
+
+    // else if it extends ArrayBufferView simply converts all the values
+    let floats = bufferFrom<Float32Array>([1.1, 2.2, 3.3]);
+    let floatBuff = Buffer.from<Float32Array>(floats);
+    let floatBuffExpected = bufferFrom<Buffer>([1, 2, 3]);
+    expect<ArrayBuffer>(floatBuff.buffer).toStrictEqual(floatBuffExpected.buffer);
+
+    let strArrayExpected = bufferFrom<Buffer>([1, 2, 3, 4, 5, 6, 7, 0, 0, 0]);
+    let stringValues: string[] = ["1.1", "2.2", "3.3", "4.4", "5.5", "6.6", "7.7", "Infinity", "NaN", "-Infinity"];
+    let strArrayActual = Buffer.from<Array<String>>(stringValues);
+    expect<ArrayBuffer>(strArrayActual.buffer).toStrictEqual(strArrayExpected.buffer);
   });
 });


### PR DESCRIPTION
Implements `Buffer.from<T>(value: T)` and a few other convenience functions.

There are lots of obvious problems with not having the function overloads, but there are different paths we can take.

For instance, because there are no optional parameters, we must assume that the default encoding for strings is `UTF8`.

```ts
// utf-16 has a work around in AssemblyScript
let buff = Buffer.from(String.UTF16.encode(value));

// using Buffer.fromString(value, "utf16le");
```

Things to note about this function:

- `String[]` objects do something complicated: string -> f64 -> u8 to remain compatible with node.

```ts
> Buffer.from(["3", "257.3", "15", "Infinity", "NaN"])
<Buffer 03 01 0F 00 00>
```

- `String` objects need to be converted to `UTF8`
- `Buffer` objects share their view of the same `ArrayBuffer`
- `ArrayBuffer` objects are simply attached to a new `Buffer`
- `ArrayBufferView` objects need to convert their values to `u8`.
