### PR TITLE
[Implement] Buffer.compare

### DIFF
--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -22,4 +22,14 @@ export class Buffer extends Uint8Array {
     result.dataLength = size;
     return result;
   }
+
+  public static readonly compare: (a: Buffer, b: Buffer) => i32 = (a: Buffer, b: Buffer): i32 => {
+    let compareLength = min<i32>(a.length, b.length);
+    let result = memory.compare(a.dataStart, b.dataStart, compareLength);
+    if (result == 0) {
+      return a.length - b.length;
+    } else {
+      return result;
+    }
+  };
 }

--- a/assembly/node.d.ts
+++ b/assembly/node.d.ts
@@ -3,4 +3,6 @@ declare class Buffer extends Uint8Array {
   static alloc(size: i32): Buffer;
   /** This method allocates a new Buffer of indicated size. This is unsafe because the data is not zeroed. */
   static allocUnsafe(size: i32): Buffer;
+  /** This method is used for sorting Buffer objects. */
+  static compare(a: Buffer, b: Buffer): i32;
 }

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -1,3 +1,10 @@
+function instantiateFrom<T>(values: valueof<T>[]): T {
+  let result = instantiate<T>(values.length);
+  // @ts-ignore
+  for (let i = 0; i < values.length; i++) result[i] = values[i];
+  return result;
+}
+
 /**
  * This is the buffer test suite. For each prototype function, put a single test
  * function call here.
@@ -41,5 +48,17 @@ describe("buffer", () => {
     expect<u32>(buff.byteLength).toBe(100);
     // TODO: expectFn(() => { Buffer.allocUnsafe(-1); }).toThrow();
     // TODO: expectFn(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
+  });
+
+  test("#compare", () => {
+    let a = instantiateFrom<Buffer>([0x05, 0x06, 0x07, 0x08]);
+    let b = instantiateFrom<Buffer>([0x01, 0x02, 0x03]);
+    let c = instantiateFrom<Buffer>([0x05, 0x06, 0x07]);
+    let d = instantiateFrom<Buffer>([0x04, 0x05, 0x06]);
+
+    let actual: Buffer[] = [a, b, c, d];
+    actual.sort(Buffer.compare);
+    let expected: Buffer[] = [b, d, c, a];
+    expect<Buffer[]>(actual).toStrictEqual(expected);
   });
 });

--- a/tests/node.js
+++ b/tests/node.js
@@ -153,3 +153,7 @@ function runTest(file, type, binary, wat) {
   wasi.view = new DataView(wasm.memory.buffer);
   context.run(wasm);
 }
+
+if (errors.length > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Notes:
- this function works really nicely with `memory.compare()`
- ~Currently, the compiler doesn't like using `static` functions as function parameters (Will open an issue in the AssemblyScript repo)~

```
ERROR AS218: Cannot access method 'compare' without calling it as it requires 'this' to be set.

     actual.sort(Buffer.compare);
                 ~~~~~~~~~~~~~~
 in tests/buffer.spec.ts(60,16)
```

Edit:

- ~Switching to `static readonly` function expression causes this to compile~