### PR TITLE
Update to latest as-pect, fix compiler errors

### DIFF
--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -15,7 +15,7 @@ export class Buffer extends Uint8Array {
 
   @unsafe static allocUnsafe(size: i32): Buffer {
     // range must be valid
-    if (i32(<usize>size > BLOCK_MAXSIZE) | i32(size < 0)) throw new RangeError(E_INVALIDLENGTH);
+    if (<usize>size > BLOCK_MAXSIZE) throw new RangeError(E_INVALIDLENGTH);
     let buffer = __alloc(size, idof<ArrayBuffer>());
     let result = __alloc(offsetof<Buffer>(), idof<Buffer>());
 

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -5,28 +5,6 @@ import { Uint8Array } from "typedarray";
 export class Buffer extends Uint8Array {
   [key: number]: u8;
 
-  @operator("[]")
-  private __get(index: i32): u8 {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
-    return load<u8>(this.dataStart + <usize>index);
-  }
-
-  @unsafe @operator("{}")
-  private __uget(index: i32): u8 {
-    return load<u8>(this.dataStart + <usize>index);
-  }
-
-  @operator("[]=")
-  private __set(index: i32, value: native<u8>): void {
-    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
-    store<u8>(this.dataStart + <usize>index, value);
-  }
-
-  @unsafe @operator("{}=")
-  private __uset(index: i32, value: native<u8>): void {
-    store<u8>(this.dataStart + <usize>index, value);
-  }
-
   constructor(size: i32) {
     super(size);
   }
@@ -269,12 +247,12 @@ export class Buffer extends Uint8Array {
   }
 
   swap16(): Buffer {
-    let byteLength = this.byteLength;
+    let byteLength = <usize>this.byteLength;
     // Make sure byteLength is even
     if (byteLength & 1) throw new RangeError(E_INVALIDLENGTH);
     let dataStart = this.dataStart;
     byteLength += dataStart;
-    while (dataStart < <usize>byteLength) {
+    while (dataStart < byteLength) {
       store<u16>(dataStart, bswap(load<u16>(dataStart)));
       dataStart += 2;
     }
@@ -282,12 +260,12 @@ export class Buffer extends Uint8Array {
   }
 
   swap32(): Buffer {
-    let byteLength = this.byteLength;
+    let byteLength = <usize>this.byteLength;
     // Make sure byteLength is divisible by 4
     if (byteLength & 3) throw new RangeError(E_INVALIDLENGTH);
     let dataStart = this.dataStart;
     byteLength += dataStart;
-    while (dataStart < <usize>byteLength) {
+    while (dataStart < byteLength) {
       store<u32>(dataStart, bswap(load<u32>(dataStart)));
       dataStart += 4;
     }
@@ -295,7 +273,7 @@ export class Buffer extends Uint8Array {
   }
 
   swap64(): Buffer {
-    let byteLength = this.byteLength;
+    let byteLength = <usize>this.byteLength;
     // Make sure byteLength is divisible by 8
     if (byteLength & 7) throw new RangeError(E_INVALIDLENGTH);
     let dataStart = this.dataStart;
@@ -313,8 +291,8 @@ export namespace Buffer {
     /** Calculates the byte length of the specified string when encoded as HEX. */
     export function byteLength(str: string): i32 {
       let ptr = changetype<usize>(str);
-      let byteCount = changetype<BLOCK>(changetype<usize>(str) - BLOCK_OVERHEAD).rtSize;
-      let length = byteCount >> 2;
+      let byteCount = <usize>changetype<BLOCK>(changetype<usize>(str) - BLOCK_OVERHEAD).rtSize;
+      let length = byteCount >>> 2;
       // The string length must be even because the bytes come in pairs of characters two wide
       if (byteCount & 3) return 0; // encoding fails and returns an empty ArrayBuffer
 
@@ -330,7 +308,7 @@ export namespace Buffer {
           return 0;
         }
       }
-      return length;
+      return <i32>length;
     }
 
     /** Creates an ArrayBuffer from a given string that is encoded in the HEX format. */
@@ -341,7 +319,7 @@ export namespace Buffer {
 
       // long path: loop over each enociding pair and perform the conversion
       let ptr = changetype<usize>(str);
-      let byteEnd = changetype<BLOCK>(changetype<usize>(str) - BLOCK_OVERHEAD).rtSize + ptr;
+      let byteEnd = ptr + <usize>changetype<BLOCK>(changetype<usize>(str) - BLOCK_OVERHEAD).rtSize;
       let result = __alloc(bufferLength, idof<ArrayBuffer>());
       let b: u32 = 0;
       let outChar = 0;

--- a/assembly/buffer/index.ts
+++ b/assembly/buffer/index.ts
@@ -3,6 +3,30 @@ import { E_INVALIDLENGTH, E_INDEXOUTOFRANGE } from "util/error";
 import { Uint8Array } from "typedarray";
 
 export class Buffer extends Uint8Array {
+  [key: number]: u8;
+
+  @operator("[]")
+  private __get(index: i32): u8 {
+    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    return load<u8>(this.dataStart + <usize>index);
+  }
+
+  @unsafe @operator("{}")
+  private __uget(index: i32): u8 {
+    return load<u8>(this.dataStart + <usize>index);
+  }
+
+  @operator("[]=")
+  private __set(index: i32, value: native<u8>): void {
+    if (<u32>index >= <u32>this.byteLength) throw new RangeError(E_INDEXOUTOFRANGE);
+    store<u8>(this.dataStart + <usize>index, value);
+  }
+
+  @unsafe @operator("{}=")
+  private __uset(index: i32, value: native<u8>): void {
+    store<u8>(this.dataStart + <usize>index, value);
+  }
+
   constructor(size: i32) {
     super(size);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,31 @@
   "requires": true,
   "dependencies": {
     "@as-pect/assembly": {
-      "version": "3.1.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-3.1.0-alpha.0.tgz",
-      "integrity": "sha512-/WA1SZnfKvXqQEYgVxub4kHi1YDccnrCFWE3mBHz3BECNGrealVWv2RYqANl26ZACdz1PxG95DGyEl6OvyNu3g==",
+      "version": "3.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-3.1.0-beta.3.tgz",
+      "integrity": "sha512-NYMzh8c4mloGJHQEyEz7Gw4DFKDjepyuSkojca0agSOVsjJcaTy6DtM42Lq7DTLwNoM4xt+YI7nQNTWcrhhHGw==",
       "dev": true
     },
     "@as-pect/core": {
-      "version": "3.1.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-3.1.0-alpha.0.tgz",
-      "integrity": "sha512-5XfvlZHGD5f47Ppc41eVxF5j/L/iFUZLpDz37slunEPipI3JIHUNraUj+hJEIsCbkX6zdlsluMxtr7IYVg1jmQ==",
+      "version": "3.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-3.1.0-beta.3.tgz",
+      "integrity": "sha512-/i3wzOYEvvzECRKLPWm7FGKnPgtD6RdaPFWAT6nA4OHtsHdHz2BvvGdCecheLRG3GoRk00LfCSRB8/L3IJnS/A==",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^3.1.0-alpha.0",
+        "@as-pect/assembly": "^3.1.0-beta.3",
+        "@as-pect/snapshots": "^3.1.0-beta.3",
         "chalk": "^3.0.0",
         "long": "^4.0.0"
+      }
+    },
+    "@as-pect/snapshots": {
+      "version": "3.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@as-pect/snapshots/-/snapshots-3.1.0-beta.3.tgz",
+      "integrity": "sha512-hL+a3/ByQQAhLLVsY9Qtd0eAb9UTZbMeJyh4mKQQS4X9KXhpVHADjoK31PbOlM+E3TUbR/KbZFFPu2Z79T3How==",
+      "dev": true,
+      "requires": {
+        "diff": "^4.0.2",
+        "nearley": "^2.19.1"
       }
     },
     "@types/color-name": {
@@ -38,12 +49,12 @@
       }
     },
     "assemblyscript": {
-      "version": "0.9.2-nightly.20200228",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.2-nightly.20200228.tgz",
-      "integrity": "sha512-leL/jjCuEwwMah4zJS11nVRN2mCm6xOjJ8XYWgpy8f3M6URkBnXHmr32ReQaSixDhzyfTWDs4JjqT5tYN1nYVA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.3.tgz",
+      "integrity": "sha512-5Mm15oLOi4Uj/N9h2uGuy4U2zFpaOQuP3kcRuFYiTchuvKIpyqqihMm+e7P6VaTLzPnN+oIRwn1KjTyo4aSw1A==",
       "dev": true,
       "requires": {
-        "binaryen": "90.0.0-nightly.20200214",
+        "binaryen": "91.0.0-nightly.20200310",
         "long": "^4.0.0"
       }
     },
@@ -54,9 +65,9 @@
       "dev": true
     },
     "binaryen": {
-      "version": "90.0.0-nightly.20200214",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200214.tgz",
-      "integrity": "sha512-ZHajaPd2aP6kDrM9q77afnA402Ufsuw9yLUxtAfgmIglP1JMB2XSRmaXc5pgCELaX53PWJIdcH07LL8uNfTBRw==",
+      "version": "91.0.0-nightly.20200310",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-91.0.0-nightly.20200310.tgz",
+      "integrity": "sha512-MmDzq267aa61HdEQeYiz+7guJlsYk2/6NxWC8I4w1jijqDwoqyZZxi7UYnTH7QvfLrNdMjweEgfT7FHjkvkPmQ==",
       "dev": true
     },
     "brace-expansion": {
@@ -94,10 +105,28 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
     "fs.realpath": {
@@ -157,6 +186,25 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+      "dev": true
+    },
+    "nearley": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.1.tgz",
+      "integrity": "sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -170,6 +218,34 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "assemblyscript": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.2.tgz",
-      "integrity": "sha512-eqPbxS323ivXdUclGJjvihxEEMBaXcNYHLb17j3j3UaYvkqVPNSrNuJ/H1r7G/UwmQnFQ8NDrQ9BncOFCGmahg==",
+      "version": "0.9.2-nightly.20200228",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.2-nightly.20200228.tgz",
+      "integrity": "sha512-leL/jjCuEwwMah4zJS11nVRN2mCm6xOjJ8XYWgpy8f3M6URkBnXHmr32ReQaSixDhzyfTWDs4JjqT5tYN1nYVA==",
       "dev": true,
       "requires": {
         "binaryen": "90.0.0-nightly.20200214",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,49 +5,46 @@
   "requires": true,
   "dependencies": {
     "@as-pect/assembly": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-2.3.1.tgz",
-      "integrity": "sha512-KYBhyTEnaVcJjN/1EpzLhpbUHKT3pJjCPxm+Mdc7obnZ9EdVz6vN/lw+BQjeL4cUi1YLsnvgl8ftXcup5jVbQA==",
+      "version": "3.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/assembly/-/assembly-3.1.0-alpha.0.tgz",
+      "integrity": "sha512-/WA1SZnfKvXqQEYgVxub4kHi1YDccnrCFWE3mBHz3BECNGrealVWv2RYqANl26ZACdz1PxG95DGyEl6OvyNu3g==",
       "dev": true
     },
     "@as-pect/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-iwd4MkGuO1wZqo9/sPlT567XYK0PkMLzBvwfkXOM2zq1wwuc5GZQrKoofgYorA40KI0edJW39djtOmPwIhx2vA==",
+      "version": "3.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@as-pect/core/-/core-3.1.0-alpha.0.tgz",
+      "integrity": "sha512-5XfvlZHGD5f47Ppc41eVxF5j/L/iFUZLpDz37slunEPipI3JIHUNraUj+hJEIsCbkX6zdlsluMxtr7IYVg1jmQ==",
       "dev": true,
       "requires": {
-        "@as-pect/assembly": "^2.3.1",
-        "chalk": "^2.4.2",
-        "csv-stringify": "^5.3.0",
+        "@as-pect/assembly": "^3.1.0-alpha.0",
+        "chalk": "^3.0.0",
         "long": "^4.0.0"
       }
     },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
       }
     },
     "assemblyscript": {
-      "version": "github:assemblyscript/assemblyscript#227c626921175ab19701752397fa513171750d38",
-      "from": "github:assemblyscript/assemblyscript",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.9.2.tgz",
+      "integrity": "sha512-eqPbxS323ivXdUclGJjvihxEEMBaXcNYHLb17j3j3UaYvkqVPNSrNuJ/H1r7G/UwmQnFQ8NDrQ9BncOFCGmahg==",
       "dev": true,
       "requires": {
-        "@protobufjs/utf8": "^1.1.0",
-        "binaryen": "87.0.0-nightly.20190716",
-        "glob": "^7.1.4",
-        "long": "^4.0.0",
-        "opencollective-postinstall": "^2.0.0",
-        "source-map-support": "^0.5.12"
+        "binaryen": "90.0.0-nightly.20200214",
+        "long": "^4.0.0"
       }
     },
     "balanced-match": {
@@ -57,19 +54,10 @@
       "dev": true
     },
     "binaryen": {
-      "version": "87.0.0-nightly.20190716",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-87.0.0-nightly.20190716.tgz",
-      "integrity": "sha512-qRGfV8cLV4HVVo1oUCtTaDmOhbwctaW7vyW0G6HKftywWOJI9t9IsCrUEFKya50RqyEnanuS2w3nfOg4bxTGqg==",
+      "version": "90.0.0-nightly.20200214",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-90.0.0-nightly.20200214.tgz",
+      "integrity": "sha512-ZHajaPd2aP6kDrM9q77afnA402Ufsuw9yLUxtAfgmIglP1JMB2XSRmaXc5pgCELaX53PWJIdcH07LL8uNfTBRw==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -81,64 +69,35 @@
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "csv-stringify": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
-      "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "lodash.get": "~4.4.2"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
     },
     "fs.realpath": {
@@ -148,9 +107,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -162,9 +121,9 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "inflight": {
@@ -182,13 +141,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true,
-      "optional": true
     },
     "long": {
       "version": "4.0.0",
@@ -214,49 +166,19 @@
         "wrappy": "1"
       }
     },
-    "opencollective-postinstall": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "wasi": {
-      "version": "github:devsnek/node-wasi#12a0985a46589587facd8d8e161911650ef15f3b",
-      "from": "github:devsnek/node-wasi",
-      "dev": true,
-      "requires": {
-        "bindings": "^1.5.0"
+        "has-flag": "^4.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "url": "https://github.com/AssemblyScript/node/issues"
   },
   "devDependencies": {
-    "@as-pect/core": "^3.1.0-alpha.0",
-    "assemblyscript": "0.9.2-nightly.20200228",
-    "glob": "^7.1.4"
+    "@as-pect/core": "^3.1.0-beta.3",
+    "assemblyscript": "0.9.3",
+    "glob": "^7.1.6"
   },
   "scripts": {
     "test": "node --experimental-wasi-unstable-preview1 tests/node"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@as-pect/core": "^3.1.0-alpha.0",
-    "assemblyscript": "^0.9.2",
+    "assemblyscript": "0.9.2-nightly.20200228",
     "glob": "^7.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,12 @@
     "url": "https://github.com/AssemblyScript/node/issues"
   },
   "devDependencies": {
-    "@as-pect/core": "^2.3.1",
-    "assemblyscript": "github:assemblyscript/assemblyscript",
-    "glob": "^7.1.4",
-    "wasi": "github:devsnek/node-wasi"
+    "@as-pect/core": "^3.1.0-alpha.0",
+    "assemblyscript": "^0.9.2",
+    "glob": "^7.1.4"
   },
   "scripts": {
-    "test": "node tests/node"
+    "test": "node --experimental-wasi-unstable-preview1 tests/node"
   },
   "dependencies": {}
 }

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -28,7 +28,8 @@ describe("buffer", () => {
     expect(myBuffer.buffer).toBeTruthy();
     expect(myBuffer.buffer).toHaveLength(10);
     expect(() => { new Buffer(-1); }).toThrow();
-    expect(() => { new Buffer(BLOCK_MAXSIZE + 1); }).toThrow();
+    // TODO: figure out how to test block maxsize
+    // expect(() => { new Buffer(1 + BLOCK_MAXSIZE); }).toThrow();
   });
 
   test("#alloc", () => {
@@ -39,7 +40,8 @@ describe("buffer", () => {
     expect(buff.buffer).not.toBeNull();
     expect(buff.byteLength).toBe(100);
     expect(() => { Buffer.alloc(-1); }).toThrow();
-    expect(() => { Buffer.alloc(BLOCK_MAXSIZE + 1); }).toThrow();
+    // TODO: figure out how to test block maxsize
+    // expect(() => { Buffer.alloc(1 + BLOCK_MAXSIZE); }).toThrow();
   });
 
   test("#allocUnsafe", () => {
@@ -49,7 +51,8 @@ describe("buffer", () => {
     expect(buff.buffer).not.toBeNull();
     expect(buff.byteLength).toBe(100);
     expect(() => { Buffer.allocUnsafe(-1); }).toThrow();
-    expect(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
+    // TODO: figure out how to test block maxsize
+    // expect(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
   test("#isBuffer", () => {

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -85,11 +85,10 @@ describe("buffer", () => {
     expect(buff.readUInt8()).toBe(254);
     // Testing offset
     expect(buff.readUInt8(4)).toBe(47);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readUInt8(5);
-    // }).toThrow();
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readUInt8(5);
+    }).toThrow();
   });
 
   test("#writeInt8", () => {
@@ -121,7 +120,7 @@ describe("buffer", () => {
     let buff = create<Buffer>([0x0,0x05,0x0]);
     expect(buff.readInt16LE()).toBe(1280);
     expect(buff.readInt16LE(1)).toBe(5);
-    expectFn(() => {
+    expect(() => {
       let newBuff = new Buffer(1);
       newBuff.readInt16LE(0);
     }).toThrow();
@@ -187,11 +186,10 @@ describe("buffer", () => {
     expect(buff.writeUInt16LE(1280,2)).toBe(4);
     let result = create<Buffer>([0x05, 0x0, 0x0, 0x5]);
     expect(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeUInt16LE(0);
-    // }).toThrow();
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeUInt16LE(0);
+    }).toThrow();
   });
 
   test("#writeUInt16BE", () => {

--- a/tests/buffer.spec.ts
+++ b/tests/buffer.spec.ts
@@ -22,34 +22,34 @@ function create<T>(values: valueof<T>[]): T {
 
 describe("buffer", () => {
   test("#constructor", () => {
-    expect<Buffer>(new Buffer(0)).toBeTruthy();
-    expect<Buffer>(new Buffer(10)).toHaveLength(10);
+    expect(new Buffer(0)).toBeTruthy();
+    expect(new Buffer(10)).toHaveLength(10);
     let myBuffer = new Buffer(10);
-    expect<ArrayBuffer>(myBuffer.buffer).toBeTruthy();
-    expect<ArrayBuffer>(myBuffer.buffer).toHaveLength(10);
-    // TODO: expectFn(() => { new Buffer(-1); }).toThrow();
-    // TODO: expectFn(() => { new Buffer(BLOCK_MAXSIZE + 1); }).toThrow();
+    expect(myBuffer.buffer).toBeTruthy();
+    expect(myBuffer.buffer).toHaveLength(10);
+    expect(() => { new Buffer(-1); }).toThrow();
+    expect(() => { new Buffer(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
   test("#alloc", () => {
-    expect<Buffer>(Buffer.alloc(10)).toBeTruthy();
-    expect<Buffer>(Buffer.alloc(10)).toHaveLength(10);
+    expect(Buffer.alloc(10)).toBeTruthy();
+    expect(Buffer.alloc(10)).toHaveLength(10);
     let buff = Buffer.alloc(100);
     for (let i = 0; i < buff.length; i++) expect<u8>(buff[i]).toBe(0);
-    expect<ArrayBuffer | null>(buff.buffer).not.toBeNull();
-    expect<u32>(buff.byteLength).toBe(100);
-    // TODO: expectFn(() => { Buffer.alloc(-1); }).toThrow();
-    // TODO: expectFn(() => { Buffer.alloc(BLOCK_MAXSIZE + 1); }).toThrow();
+    expect(buff.buffer).not.toBeNull();
+    expect(buff.byteLength).toBe(100);
+    expect(() => { Buffer.alloc(-1); }).toThrow();
+    expect(() => { Buffer.alloc(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
   test("#allocUnsafe", () => {
-    expect<Buffer>(Buffer.allocUnsafe(10)).toBeTruthy();
-    expect<Buffer>(Buffer.allocUnsafe(10)).toHaveLength(10);
+    expect(Buffer.allocUnsafe(10)).toBeTruthy();
+    expect(Buffer.allocUnsafe(10)).toHaveLength(10);
     let buff = Buffer.allocUnsafe(100);
-    expect<ArrayBuffer | null>(buff.buffer).not.toBeNull();
-    expect<u32>(buff.byteLength).toBe(100);
-    // TODO: expectFn(() => { Buffer.allocUnsafe(-1); }).toThrow();
-    // TODO: expectFn(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
+    expect(buff.buffer).not.toBeNull();
+    expect(buff.byteLength).toBe(100);
+    expect(() => { Buffer.allocUnsafe(-1); }).toThrow();
+    expect(() => { Buffer.allocUnsafe(BLOCK_MAXSIZE + 1); }).toThrow();
   });
 
   test("#isBuffer", () => {
@@ -58,33 +58,33 @@ describe("buffer", () => {
     let c = 0;
     let d = 1.1;
     let e = new Buffer(0);
-    expect<bool>(Buffer.isBuffer<string>(a)).toBeFalsy();
-    expect<bool>(Buffer.isBuffer<Uint8Array>(b)).toBeFalsy();
-    expect<bool>(Buffer.isBuffer<i32>(c)).toBeFalsy();
-    expect<bool>(Buffer.isBuffer<f64>(d)).toBeFalsy();
-    expect<bool>(Buffer.isBuffer<Buffer>(e)).toBeTruthy();
-    // null checks are done by the compiler explicitly at runtime
-    expect<bool>(Buffer.isBuffer<Buffer | null>(null)).toBeFalsy();
+    let f: Buffer | null = null;
+
+    expect(Buffer.isBuffer(a)).toBeFalsy();
+    expect(Buffer.isBuffer(b)).toBeFalsy();
+    expect(Buffer.isBuffer(c)).toBeFalsy();
+    expect(Buffer.isBuffer(d)).toBeFalsy();
+    expect(Buffer.isBuffer(e)).toBeTruthy();
+    expect(Buffer.isBuffer(f)).toBeFalsy();
   });
 
   test("#readInt8", () => {
     let buff = create<Buffer>([0x5,0x0,0x0,0x0,0xFF]);
-    expect<i8>(buff.readInt8()).toBe(5);
+    expect(buff.readInt8()).toBe(5);
     // Testing offset, and casting between u8 and i8.
-    expect<i8>(buff.readInt8(4)).toBe(-1);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readInt8(5);
-    // }).toThrow();
+    expect(buff.readInt8(4)).toBe(-1);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readInt8(5);
+    }).toThrow();
   });
 
   test("#readUInt8", () => {
     let buff = create<Buffer>([0xFE,0x0,0x0,0x0,0x2F]);
     // Testing casting between u8 and i8.
-    expect<u8>(buff.readUInt8()).toBe(254);
+    expect(buff.readUInt8()).toBe(254);
     // Testing offset
-    expect<u8>(buff.readUInt8(4)).toBe(47);
+    expect(buff.readUInt8(4)).toBe(47);
     // TODO:
     // expectFn(() => {
     //   let newBuff = new Buffer(1);
@@ -94,106 +94,99 @@ describe("buffer", () => {
 
   test("#writeInt8", () => {
     let buff = new Buffer(5);
-    expect<i32>(buff.writeInt8(9)).toBe(1);
-    expect<i32>(buff.writeInt8(-3,4)).toBe(5);
+    expect(buff.writeInt8(9)).toBe(1);
+    expect(buff.writeInt8(-3,4)).toBe(5);
     let result = create<Buffer>([0x09, 0x0, 0x0, 0x0, 0xFD]);
-    expect<Buffer>(buff).toStrictEqual(result);
+    expect(buff).toStrictEqual(result);
     // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeInt8(5,10);
-    // }).toThrow();
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeInt8(5,10);
+    }).toThrow();
   });
 
   test("#writeUInt8", () => {
     let buff = new Buffer(5);
-    expect<i32>(buff.writeUInt8(4)).toBe(1);
-    expect<i32>(buff.writeUInt8(252,4)).toBe(5);
+    expect(buff.writeUInt8(4)).toBe(1);
+    expect(buff.writeUInt8(252,4)).toBe(5);
     let result = create<Buffer>([0x04, 0x0, 0x0, 0x0, 0xFC]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeUInt8(5,10);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeUInt8(5,10);
+    }).toThrow();
   });
 
   test("#readInt16LE", () => {
     let buff = create<Buffer>([0x0,0x05,0x0]);
-    expect<i16>(buff.readInt16LE()).toBe(1280);
-    expect<i16>(buff.readInt16LE(1)).toBe(5);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readInt16LE(0);
-    // }).toThrow();
+    expect(buff.readInt16LE()).toBe(1280);
+    expect(buff.readInt16LE(1)).toBe(5);
+    expectFn(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readInt16LE(0);
+    }).toThrow();
   });
 
   test("#readInt16BE", () => {
     let buff = create<Buffer>([0x0,0x05,0x0]);
-    expect<i16>(buff.readInt16BE()).toBe(5);
-    expect<i16>(buff.readInt16BE(1)).toBe(1280);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readInt16BE(0);
-    // }).toThrow();
+    expect(buff.readInt16BE()).toBe(5);
+    expect(buff.readInt16BE(1)).toBe(1280);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readInt16BE(0);
+    }).toThrow();
   });
 
   test("#readUInt16LE", () => {
     let buff = create<Buffer>([0x0,0x05,0x0]);
-    expect<u16>(buff.readUInt16LE()).toBe(1280);
-    expect<u16>(buff.readUInt16LE(1)).toBe(5);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readUInt16LE(0);
-    // }).toThrow();
+    expect(buff.readUInt16LE()).toBe(1280);
+    expect(buff.readUInt16LE(1)).toBe(5);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readUInt16LE(0);
+    }).toThrow();
   });
 
   test("#readUInt16BE", () => {
     let buff = create<Buffer>([0x0,0x05,0x0]);
-    expect<i16>(buff.readUInt16BE()).toBe(5);
-    expect<i16>(buff.readUInt16BE(1)).toBe(1280);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readUInt16BE(0);
-    // }).toThrow();
+    expect(buff.readUInt16BE()).toBe(5);
+    expect(buff.readUInt16BE(1)).toBe(1280);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readUInt16BE(0);
+    }).toThrow();
   });
 
   test("#writeInt16LE", () => {
     let buff = new Buffer(4);
-    expect<i32>(buff.writeInt16LE(5)).toBe(2);
-    expect<i32>(buff.writeInt16LE(1280,2)).toBe(4);
+    expect(buff.writeInt16LE(5)).toBe(2);
+    expect(buff.writeInt16LE(1280,2)).toBe(4);
     let result = create<Buffer>([0x05, 0x0, 0x0, 0x5]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeInt16LE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeInt16LE(0);
+    }).toThrow();
   });
 
   test("#writeInt16BE", () => {
     let buff = new Buffer(4);
-    expect<i32>(buff.writeInt16BE(1280)).toBe(2);
-    expect<i32>(buff.writeInt16BE(5,2)).toBe(4);
+    expect(buff.writeInt16BE(1280)).toBe(2);
+    expect(buff.writeInt16BE(5,2)).toBe(4);
     let result = create<Buffer>([0x05, 0x0, 0x0, 0x5]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeInt16BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeInt16BE(0);
+    }).toThrow();
   });
 
   test("#writeUInt16LE", () => {
     let buff = new Buffer(4);
-    expect<i32>(buff.writeUInt16LE(5)).toBe(2);
-    expect<i32>(buff.writeUInt16LE(1280,2)).toBe(4);
+    expect(buff.writeUInt16LE(5)).toBe(2);
+    expect(buff.writeUInt16LE(1280,2)).toBe(4);
     let result = create<Buffer>([0x05, 0x0, 0x0, 0x5]);
-    expect<Buffer>(buff).toStrictEqual(result);
+    expect(buff).toStrictEqual(result);
     // TODO:
     // expectFn(() => {
     //   let newBuff = new Buffer(1);
@@ -203,303 +196,278 @@ describe("buffer", () => {
 
   test("#writeUInt16BE", () => {
     let buff = new Buffer(4);
-    expect<i32>(buff.writeUInt16BE(1280)).toBe(2);
-    expect<i32>(buff.writeUInt16BE(5,2)).toBe(4);
+    expect(buff.writeUInt16BE(1280)).toBe(2);
+    expect(buff.writeUInt16BE(5,2)).toBe(4);
     let result = create<Buffer>([0x05, 0x0, 0x0, 0x5]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeUInt16BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeUInt16BE(0);
+    }).toThrow();
   });
 
   test("#readInt32LE", () => {
     let buff = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);
-    expect<i32>(buff.readInt32LE()).toBe(-559038737);
-    expect<i32>(buff.readInt32LE(4)).toBe(283033613);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readInt32LE(0);
-    // }).toThrow();
+    expect(buff.readInt32LE()).toBe(-559038737);
+    expect(buff.readInt32LE(4)).toBe(283033613);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readInt32LE(0);
+    }).toThrow();
   });
 
   test("#readInt32BE", () => {
     let buff = create<Buffer>([0xDE,0xAD,0xBE,0xEF,0x10,0xde,0xc0,0x0d]);
-    expect<i32>(buff.readInt32BE()).toBe(-559038737);
-    expect<i32>(buff.readInt32BE(4)).toBe(283033613);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readInt32BE(0);
-    // }).toThrow();
+    expect(buff.readInt32BE()).toBe(-559038737);
+    expect(buff.readInt32BE(4)).toBe(283033613);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readInt32BE(0);
+    }).toThrow();
   });
 
   test("#readUInt32LE", () => {
     let buff = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);
-    expect<u32>(buff.readUInt32LE()).toBe(3735928559);
-    expect<u32>(buff.readUInt32LE(4)).toBe(283033613);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readUInt32LE(0);
-    // }).toThrow();
+    expect(buff.readUInt32LE()).toBe(3735928559);
+    expect(buff.readUInt32LE(4)).toBe(283033613);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readUInt32LE(0);
+    }).toThrow();
   });
 
   test("#readUInt32BE", () => {
     let buff = create<Buffer>([0xDE,0xAD,0xBE,0xEF,0x10,0xde,0xc0,0x0d]);
-    expect<u32>(buff.readUInt32BE()).toBe(3735928559);
-    expect<u32>(buff.readUInt32BE(4)).toBe(283033613);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readUInt32BE(0);
-    // }).toThrow();
+    expect(buff.readUInt32BE()).toBe(3735928559);
+    expect(buff.readUInt32BE(4)).toBe(283033613);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readUInt32BE(0);
+    }).toThrow();
   });
 
   test("#writeInt32LE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeInt32LE(-559038737)).toBe(4);
-    expect<i32>(buff.writeInt32LE(283033613,4)).toBe(8);
+    expect(buff.writeInt32LE(-559038737)).toBe(4);
+    expect(buff.writeInt32LE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);
     expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeInt32LE(0);
-    // }).toThrow();
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeInt32LE(0);
+    }).toThrow();
   });
 
   test("#writeInt32BE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeInt32BE(-559038737)).toBe(4);
-    expect<i32>(buff.writeInt32BE(283033613,4)).toBe(8);
+    expect(buff.writeInt32BE(-559038737)).toBe(4);
+    expect(buff.writeInt32BE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xDE,0xAD,0xBE,0xEF,0x10,0xde,0xc0,0x0d]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeInt32BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeInt32BE(0);
+    }).toThrow();
   });
 
   test("#writeUInt32LE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeUInt32LE(3735928559)).toBe(4);
-    expect<i32>(buff.writeUInt32LE(283033613,4)).toBe(8);
+    expect(buff.writeUInt32LE(3735928559)).toBe(4);
+    expect(buff.writeUInt32LE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x0d,0xc0,0xde,0x10]);;
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeUInt32LE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeUInt32LE(0);
+    }).toThrow();
   });
 
   test("#writeUInt32BE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeUInt32BE(3735928559)).toBe(4);
-    expect<i32>(buff.writeUInt32BE(283033613,4)).toBe(8);
+    expect(buff.writeUInt32BE(3735928559)).toBe(4);
+    expect(buff.writeUInt32BE(283033613,4)).toBe(8);
     let result = create<Buffer>([0xDE,0xAD,0xBE,0xEF,0x10,0xde,0xc0,0x0d]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeUInt32BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeUInt32BE(0);
+    }).toThrow();
   });
 
   test("#readFloatLE", () => {
     let buff = create<Buffer>([0xbb,0xfe,0x4a,0x4f,0x01,0x02,0x03,0x04]);
-    expect<f32>(buff.readFloatLE()).toBe(0xcafebabe);
-    expect<f32>(buff.readFloatLE(4)).toBe(1.539989614439558e-36);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readFloatLE(0);
-    // }).toThrow();
+    expect(buff.readFloatLE()).toBe(0xcafebabe);
+    expect(buff.readFloatLE(4)).toBe(1.539989614439558e-36);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readFloatLE(0);
+    }).toThrow();
   });
 
   test("#readFloatBE", () => {
     let buff = create<Buffer>([0x4f,0x4a,0xfe,0xbb,0x01,0x02,0x03,0x04]);
-    expect<f32>(buff.readFloatBE()).toBe(0xcafebabe);
-    expect<f32>(buff.readFloatBE(4)).toBe(2.387939260590663e-38);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readFloatBE(0);
-    // }).toThrow();
+    expect(buff.readFloatBE()).toBe(0xcafebabe);
+    expect(buff.readFloatBE(4)).toBe(2.387939260590663e-38);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readFloatBE(0);
+    }).toThrow();
   });
 
   test("#writeFloatLE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeFloatLE(0xcafebabe)).toBe(4);
-    expect<i32>(buff.writeFloatLE(1.539989614439558e-36,4)).toBe(8);
+    expect(buff.writeFloatLE(0xcafebabe)).toBe(4);
+    expect(buff.writeFloatLE(1.539989614439558e-36,4)).toBe(8);
     let result = create<Buffer>([0xbb,0xfe,0x4a,0x4f,0x01,0x02,0x03,0x04]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeFloatLE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeFloatLE(0);
+    }).toThrow();
   });
 
   test("#writeFloatBE", () => {
     let buff = new Buffer(8);
-    expect<i32>(buff.writeFloatBE(0xcafebabe)).toBe(4);
-    expect<i32>(buff.writeFloatBE(2.387939260590663e-38,4)).toBe(8);
+    expect(buff.writeFloatBE(0xcafebabe)).toBe(4);
+    expect(buff.writeFloatBE(2.387939260590663e-38,4)).toBe(8);
     let result = create<Buffer>([0x4f,0x4a,0xfe,0xbb,0x01,0x02,0x03,0x04]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeFloatBE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeFloatBE(0);
+    }).toThrow();
   });
 
   test("#readBigInt64LE", () => {
     let buff = create<Buffer>([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00]);
-    expect<i64>(buff.readBigInt64LE()).toBe(-4294967296);
-    expect<i64>(buff.readBigInt64LE(8)).toBe(4294967295);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readBigInt64LE(0);
-    // }).toThrow();
+    expect(buff.readBigInt64LE()).toBe(-4294967296);
+    expect(buff.readBigInt64LE(8)).toBe(4294967295);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readBigInt64LE(0);
+    }).toThrow();
   });
 
   test("#readBigInt64BE", () => {
     let buff = create<Buffer>([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00]);
-    expect<i64>(buff.readBigInt64BE()).toBe(4294967295);
-    expect<i64>(buff.readBigInt64BE(8)).toBe(-4294967296);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readBigInt64BE(0);
-    // }).toThrow();
+    expect(buff.readBigInt64BE()).toBe(4294967295);
+    expect(buff.readBigInt64BE(8)).toBe(-4294967296);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readBigInt64BE(0);
+    }).toThrow();
   });
 
   test("#readBigUInt64LE", () => {
     let buff = create<Buffer>([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00]);
-    expect<u64>(buff.readBigUInt64LE()).toBe(18446744069414584320);
-    expect<u64>(buff.readBigUInt64LE(8)).toBe(4294967295);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readBigUInt64LE(0);
-    // }).toThrow();
+    expect(buff.readBigUInt64LE()).toBe(18446744069414584320);
+    expect(buff.readBigUInt64LE(8)).toBe(4294967295);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readBigUInt64LE(0);
+    }).toThrow();
   });
 
   test("#readBigUInt64BE", () => {
     let buff = create<Buffer>([0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00]);
-    expect<u64>(buff.readBigUInt64BE()).toBe(4294967295);
-    expect<u64>(buff.readBigUInt64BE(8)).toBe(18446744069414584320);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readBigUInt64BE(0);
-    // }).toThrow();
+    expect(buff.readBigUInt64BE()).toBe(4294967295);
+    expect(buff.readBigUInt64BE(8)).toBe(18446744069414584320);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readBigUInt64BE(0);
+    }).toThrow();
   });
 
   test("#writeBigInt64LE", () => {
     let buff = new Buffer(16);
-    expect<i64>(buff.writeBigInt64LE(-559038737)).toBe(8);
-    expect<i64>(buff.writeBigInt64LE(283033613,8)).toBe(16);
+    expect(buff.writeBigInt64LE(-559038737)).toBe(8);
+    expect(buff.writeBigInt64LE(283033613,8)).toBe(16);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0xFF,0xFF,0xFF,0xFF,0x0d,0xc0,0xde,0x10,0x00,0x00,0x00,0x00]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeBigInt64LE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeBigInt64LE(0);
+    }).toThrow();
   });
 
   test("#writeBigInt64BE", () => {
     let buff = new Buffer(16);
-    expect<i64>(buff.writeBigInt64BE(-559038737)).toBe(8);
-    expect<i64>(buff.writeBigInt64BE(283033613,8)).toBe(16);
+    expect(buff.writeBigInt64BE(-559038737)).toBe(8);
+    expect(buff.writeBigInt64BE(283033613,8)).toBe(16);
     let result = create<Buffer>([0xFF,0xFF,0xFF,0xFF,0xDE,0xAD,0xBE,0xEF,0x00,0x00,0x00,0x00,0x10,0xde,0xc0,0x0d]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeBigInt64BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeBigInt64BE(0);
+    }).toThrow();
   });
 
   test("#writeBigUInt64LE", () => {
     let buff = new Buffer(16);
-    expect<i64>(buff.writeBigUInt64LE(3735928559)).toBe(8);
-    expect<i64>(buff.writeBigUInt64LE(283033613,8)).toBe(16);
+    expect(buff.writeBigUInt64LE(3735928559)).toBe(8);
+    expect(buff.writeBigUInt64LE(283033613,8)).toBe(16);
     let result = create<Buffer>([0xEF,0xBE,0xAD,0xDE,0x00,0x00,0x00,0x00,0x0d,0xc0,0xde,0x10,0x00,0x00,0x00,0x00]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeBigUInt64LE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeBigUInt64LE(0);
+    }).toThrow();
   });
 
   test("#writeBigUInt64BE", () => {
     let buff = new Buffer(16);
-    expect<i64>(buff.writeBigUInt64BE(3735928559)).toBe(8);
-    expect<i64>(buff.writeBigUInt64BE(283033613,8)).toBe(16);
+    expect(buff.writeBigUInt64BE(3735928559)).toBe(8);
+    expect(buff.writeBigUInt64BE(283033613,8)).toBe(16);
     let result = create<Buffer>([0x00,0x00,0x00,0x00,0xDE,0xAD,0xBE,0xEF,0x00,0x00,0x00,0x00,0x10,0xde,0xc0,0x0d]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeBigUInt64BE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeBigUInt64BE(0);
+    }).toThrow();
   });
 
   test("#readDoubleLE", () => {
     let buff = create<Buffer>([0x77, 0xbe, 0x9f, 0x1a, 0x2f, 0xdd, 0x5e, 0x40, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-    expect<f64>(buff.readDoubleLE()).toBe(123.456);
-    expect<f64>(buff.readDoubleLE(8)).toBe(5.447603722011605e-270);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readDoubleLE(0);
-    // }).toThrow();
+    expect(buff.readDoubleLE()).toBe(123.456);
+    expect(buff.readDoubleLE(8)).toBe(5.447603722011605e-270);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readDoubleLE(0);
+    }).toThrow();
   });
 
   test("#readDoubleBE", () => {
     let buff = create<Buffer>([0x40, 0x5e, 0xdd, 0x2f, 0x1a, 0x9f, 0xbe, 0x77, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-    expect<f64>(buff.readDoubleBE()).toBe(123.456);
-    expect<f64>(buff.readDoubleBE(8)).toBe(8.20788039913184e-304);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.readDoubleBE(0);
-    // }).toThrow();
+    expect(buff.readDoubleBE()).toBe(123.456);
+    expect(buff.readDoubleBE(8)).toBe(8.20788039913184e-304);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.readDoubleBE(0);
+    }).toThrow();
   });
 
   test("#writeDoubleLE", () => {
     let buff = new Buffer(16);
-    expect<i32>(buff.writeDoubleLE(123.456)).toBe(8);
-    expect<i32>(buff.writeDoubleLE(5.447603722011605e-270,8)).toBe(16);
+    expect(buff.writeDoubleLE(123.456)).toBe(8);
+    expect(buff.writeDoubleLE(5.447603722011605e-270,8)).toBe(16);
     let result = create<Buffer>([0x77, 0xbe, 0x9f, 0x1a, 0x2f, 0xdd, 0x5e, 0x40, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeDoubleLE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeDoubleLE(0);
+    }).toThrow();
   });
 
   test("#writeDoubleBE", () => {
     let buff = new Buffer(16);
-    expect<i32>(buff.writeDoubleBE(123.456)).toBe(8);
-    expect<i32>(buff.writeDoubleBE(8.20788039913184e-304,8)).toBe(16);
+    expect(buff.writeDoubleBE(123.456)).toBe(8);
+    expect(buff.writeDoubleBE(8.20788039913184e-304,8)).toBe(16);
     let result = create<Buffer>([0x40, 0x5e, 0xdd, 0x2f, 0x1a, 0x9f, 0xbe, 0x77, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
-    expect<Buffer>(buff).toStrictEqual(result);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = new Buffer(1);
-    //   newBuff.writeDoubleBE(0);
-    // }).toThrow();
+    expect(buff).toStrictEqual(result);
+    expect(() => {
+      let newBuff = new Buffer(1);
+      newBuff.writeDoubleBE(0);
+    }).toThrow();
   });
 
   test("#subarray", () => {
@@ -507,81 +475,78 @@ describe("buffer", () => {
 
     // no parameters means copy the Buffer
     let actual = example.subarray();
-    expect<Buffer>(actual).toStrictEqual(example);
-    expect<ArrayBuffer>(actual.buffer).toBe(example.buffer); // should use the same buffer
+    expect(actual).toStrictEqual(example);
+    expect(actual.buffer).toBe(example.buffer); // should use the same buffer
 
     // start at offset 5
     actual = example.subarray(5);
     let expected = create<Buffer>([6, 7, 8]);
     // trace("length", 1, expected.length);
-    expect<Buffer>(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected);
 
     // negative start indicies, start at (8 - 5)
     actual = example.subarray(-5);
     expected = create<Buffer>([4, 5, 6, 7, 8]);
-    expect<Buffer>(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected);
 
     // two parameters
     actual = example.subarray(2, 6);
     expected = create<Buffer>([3, 4, 5, 6]);
-    expect<Buffer>(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected);
 
     // negative end index
     actual = example.subarray(4, -1);
     expected = create<Buffer>([5, 6, 7]);
-    expect<Buffer>(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual(expected);
   });
 
   test("#swap16", () => {
     let actual = create<Buffer>([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
     let expected = create<Buffer>([0x2, 0x1, 0x4, 0x3, 0x6, 0x5, 0x8, 0x7]);
     let swapped = actual.swap16();
-    expect<Buffer>(actual).toStrictEqual(expected);
-    expect<Buffer>(swapped).toBe(actual);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
-    //   newBuff.swap16();
-    // }).toThrow();
+    expect(actual).toStrictEqual(expected);
+    expect(swapped).toBe(actual);
+    expect(() => {
+      let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
+      newBuff.swap16();
+    }).toThrow();
   });
 
   test("#swap32", () => {
     let actual = create<Buffer>([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]);
     let expected = create<Buffer>([0x4, 0x3, 0x2, 0x1, 0x8, 0x7, 0x6, 0x5]);
     let swapped = actual.swap32();
-    expect<Buffer>(actual).toStrictEqual(expected);
-    expect<Buffer>(swapped).toBe(actual);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
-    //   newBuff.swap64();
-    // }).toThrow();
+    expect(actual).toStrictEqual(expected);
+    expect(swapped).toBe(actual);
+    expect(() => {
+      let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
+      newBuff.swap64();
+    }).toThrow();
   });
 
   test("#swap64", () => {
     let actual = create<Buffer>([0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf]);
     let expected = create<Buffer>([0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0x0, 0xf, 0xe, 0xd, 0xc, 0xb, 0xa, 0x9, 0x8]);
     let swapped = actual.swap64();
-    expect<Buffer>(actual).toStrictEqual(expected);
-    expect<Buffer>(swapped).toBe(actual);
-    // TODO:
-    // expectFn(() => {
-    //   let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
-    //   newBuff.swap64();
-    // }).toThrow();
+    expect(actual).toStrictEqual(expected);
+    expect(swapped).toBe(actual);
+    expect(() => {
+      let newBuff = create<Buffer>([0x1, 0x2, 0x3]);
+      newBuff.swap64();
+    }).toThrow();
   });
-                       
+
   test("#Hex.encode", () => {
     let actual = "000102030405060708090a0b0c0d0e0f102030405060708090a0b0c0d0e0f0";
     let exampleBuffer = create<Buffer>([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0]);
     let encoded = Buffer.HEX.encode(actual);
-    expect<ArrayBuffer>(encoded).toStrictEqual(exampleBuffer.buffer);
+    expect(encoded).toStrictEqual(exampleBuffer.buffer);
   });
 
   test("#Hex.decode", () => {
     let expected = "000102030405060708090a0b0c0d0e0f102030405060708090a0b0c0d0e0f0";
     let exampleBuffer = create<Buffer>([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0]);
     let decoded = Buffer.HEX.decode(exampleBuffer.buffer);
-    expect<string>(decoded).toStrictEqual(expected);
+    expect(decoded).toStrictEqual(expected);
   });
 });

--- a/tests/node.js
+++ b/tests/node.js
@@ -137,8 +137,10 @@ function runTest(fileName, type, binary, wat) {
   const imports = context.createImports({
     wasi_snapshot_preview1: wasi.wasiImport,
   });
+
   const instance = instantiateSync(binary, imports);
   // TODO: wasi.start(instance);
+  process.stdout.write("\n");
   context.run(instance);
 
   if (!context.pass) pass = false;

--- a/tests/node.js
+++ b/tests/node.js
@@ -117,8 +117,8 @@ for (const file of files) {
   process.stdout.write("\n");
 }
 
-function runTest(file, type, binary, wat) {
-  const watPath = path.join(path.dirname(file), path.basename(file, ".ts"))
+function runTest(fileName, type, binary, wat) {
+  const watPath = path.join(path.dirname(fileName), path.basename(fileName, ".ts"))
     + "." + type +  ".wat";
 
   // should not block testing
@@ -127,9 +127,11 @@ function runTest(file, type, binary, wat) {
   });
 
   const context = new TestContext({
-    fileName: file,
-    reporter,
+    fileName, // set the fileName
+    reporter, // use verbose reporter
+    binary, // pass the binary to get function names
   });
+
   const imports = context.createImports({
     wasi_snapshot_preview1: wasi.wasiImport,
   });

--- a/tests/node.js
+++ b/tests/node.js
@@ -141,4 +141,4 @@ function runTest(file, type, binary, wat) {
   if (!context.pass) pass = false;
 }
 
-process.exit(pass ? 0 : 1);
+process.exit(pass && errors.length === 0 ? 0 : 1);


### PR DESCRIPTION
Alright! Time to get working on this.

This currently breaks because of a compiler error. Inheriting from `Uint8Array` causes a compiler error, when accessing the bytes via the index signature:

```
ERROR TS2329: Index signature is missing in type '~lib/buffer/index/Buffer'.

   for (let i = 0; i < values.length; i++) result[i] = values[i];
```

Please advise 👍 

Also, there seems to be an issue with `Reflect.equals()` which may potentially be a bug in my testing software, or is possibly related to the fact that type information is not passed from `Buffer` index signature. I'm confident it's the latter.