### PR TITLE
docs: fix incorrect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $> npm install --save-dev AssemblyScript/node
 and include it in your build step to gain access to the implementations it provides:
 
 ```
-$> asc --lib ./node_modules/@assemblyscript/node/assembly [...]
+$> asc ./node_modules/@assemblyscript/node/assembly --lib [...]
 ```
 
 Doing so will automatically register common globals like the `Buffer` class and enables requiring


### PR DESCRIPTION
The original command does not run because options should come after the entry file:
```
SYNTAX
  asc [entryFile ...] [options]
```